### PR TITLE
Bugfix and tests for issue #1

### DIFF
--- a/lib/readable.js
+++ b/lib/readable.js
@@ -55,7 +55,7 @@ function Readable(id, options) {
     this.open();
   });
 
-  this.once('finish', this.close);
+  this.once('end', this.close);
 
 }
 
@@ -121,8 +121,6 @@ app.nextPage = function() {
   var self = this,
       next = this.page + 1;
 
-  this.close();
-
   this.helpers.filePath(this.id, next, function(err, file) {
 
     if(err) {
@@ -132,6 +130,7 @@ app.nextPage = function() {
     fs.exists(file, function(exists) {
 
       if(exists) {
+        self.close();
         self.page = next;
         self.file = file;
         return self.open();
@@ -259,7 +258,6 @@ app._read = function() {
 app.close = function() {
 
   var self = this;
-
   fs.close(this.fd, function(err) {
 
     if(err) {


### PR DESCRIPTION
Fix as explained in the issue.
- Change close event listener in initializer from `finish` to `end` (reader streams emit end not finish when out of data).
- Move the `this.close()` in `nextPage` to make sure there always exists a file to close when the `end` event is fired.
